### PR TITLE
Skip hand-object interactions when the object is below detection thre…

### DIFF
--- a/src/public_lib/epic_kitchens/hoa/types.py
+++ b/src/public_lib/epic_kitchens/hoa/types.py
@@ -299,6 +299,7 @@ class FrameDetections:
             if (
                 hand_detection.state.value == HandState.NO_CONTACT.value
                 or hand_detection.score <= hand_threshold
+                or len(object_centers) == 0
             ):
                 continue
             estimated_object_position = (


### PR DESCRIPTION
Hello,

Thanks for the great work.

When testing the code, I had some errors when a hand-object pair has been detected, but the object had insufficient confidence value. This causes the `object_centers` list to be null, leading to the following error:
```
Traceback (most recent call last):
  File "test.py", line 49, in <module>
    im = renderer.render_detections(frames[frame_idx], video_detections[frame_idx])
  File "/home/affonso/epic-kitchens-100-hand-object-bboxes/src/public_lib/epic_kitchens/hoa/visualisation.py", line 93, in render_detections
    hand_object_idx_correspondences = detections.get_hand_object_interactions(
  File "/home/affonso/epic-kitchens-100-hand-object-bboxes/src/public_lib/epic_kitchens/hoa/types.py", line 309, in get_hand_object_interactions
    distances = ((object_centers - estimated_object_position) ** 2).sum(
ValueError: operands could not be broadcast together with shapes (0,) (2,) 
```
In this PR I am fixing this by skipping evaluation when the `object_centers` does not hold any values.